### PR TITLE
Build long prefix package using conda-build 2.x

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,14 @@ install:
       conda install --yes --quiet conda-forge-build-setup
       source run_conda_forge_build_setup
 
+      # install conda-build 2.x to build with a long prefix
+      conda install --yes --quiet conda-build=2
+      conda info
+
 script:
   - conda build ./recipe
 
   - upload_or_check_non_existence ./recipe conda-forge --channel=main
+
+# inspect the prefix lengths of the built packages
+  - conda inspect prefix-lengths /Users/travis/miniconda3/conda-bld/osx-64/*.tar.bz2

--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ which have API conforming to C99 and POSIX. Tokyo Cabinet is a
 free software licensed under the GNU Lesser General Public License.
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/tokyocabinet-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/tokyocabinet-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/tokyocabinet-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/tokyocabinet-feedstock)
+Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/tokyocabinet/badges/version.svg)](https://anaconda.org/conda-forge/tokyocabinet)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/tokyocabinet/badges/downloads.svg)](https://anaconda.org/conda-forge/tokyocabinet)
+
 Installing tokyocabinet
 =======================
 
@@ -89,18 +101,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/tokyocabinet-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/tokyocabinet-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/tokyocabinet-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/tokyocabinet-feedstock)
-Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/tokyocabinet/badges/version.svg)](https://anaconda.org/conda-forge/tokyocabinet)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/tokyocabinet/badges/downloads.svg)](https://anaconda.org/conda-forge/tokyocabinet)
 
 
 Updating tokyocabinet-feedstock

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,7 +41,13 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
+# install conda-build 2.x to build with a long prefix
+conda install --yes --quiet conda-build=2
+conda info
+
 # Embarking on 1 case(s).
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+# inspect the prefix lengths of the built packages
+conda inspect prefix-lengths /feedstock_root/build_artefacts/linux-64/*.tar.bz2
 EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
   detect_binary_files_with_prefix: true


### PR DESCRIPTION
Create a conda package with a long prefix (255 characters) using conda-build 2.x